### PR TITLE
Allow multiple /ExtraFlags parameters to work

### DIFF
--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -41,7 +41,7 @@ if ($pp["RemoteAddresses"] -ne $null -and $pp["RemoteAddresses"] -ne '') {
 }
 
 if ($pp["ExtraFlags"] -ne $null -and $pp["ExtraFlags"] -ne '') {
-  $silentArgs += " EXTRA_FLAGS=$($pp["ExtraFlags"])"
+  $silentArgs += " EXTRA_FLAGS=`"$($pp["ExtraFlags"])`""
   Write-Host "Extra flags: `'$($pp["ExtraFlags"])`'"
 }
 


### PR DESCRIPTION
This fixes issue: https://github.com/andrewmostello/prometheus-windows-exporter.install/issues/13

This surrounds the `/ExtraFlags` string with double-quotes and then when this gets passed to `msiexec.exe` it's using the correct syntax for the installer as documented in the [Windows Exporter Install docs](https://github.com/prometheus-community/windows_exporter#installation), for example:

```
EXTRA_FLAGS="--collectors.mssql.classes-enabled=accessmethods,bufman,databases,genstats,locks,memmgr,sqlstats,sqlerrors,transactions,waitstats --collector.logical_disk.volume-exclude=[E]:"
```

Excerpted from the `chocolatey.log` showing the args passed to `msiexec.exe` by `choco`:

```
2023-11-14 17:19:55,367 8180 [DEBUG] - Elevating permissions and running ["C:\Windows\System32\msiexec.exe" /i "C:\Users\Administrator\AppData\Local\Temp\2\chocolatey\prometheus-windows-exporter.install\0.24.0\prometheus-windows-exporter.installInstall.msi" /qn /norestart /l*v "C:\Users\Administrator\AppData\Local\Temp\2\chocolatey\prometheus-windows-exporter.install.0.24.0.MsiInstall.log" LISTEN_PORT=7821 EXTRA_FLAGS="--collectors.mssql.classes-enabled=accessmethods,bufman,databases,genstats,locks,memmgr,sqlstats,sqlerrors,transactions,waitstats --collector.logical_disk.volume-exclude=[E]:" ]. This may take a while, depending on the statements.
2023-11-14 17:19:58,506 8180 [DEBUG] - Command ["C:\Windows\System32\msiexec.exe" /i "C:\Users\Administrator\AppData\Local\Temp\2\chocolatey\prometheus-windows-exporter.install\0.24.0\prometheus-windows-exporter.installInstall.msi" /qn /norestart /l*v "C:\Users\Administrator\AppData\Local\Temp\2\chocolatey\prometheus-windows-exporter.install.0.24.0.MsiInstall.log" LISTEN_PORT=7821 EXTRA_FLAGS="--collectors.mssql.classes-enabled=accessmethods,bufman,databases,genstats,locks,memmgr,sqlstats,sqlerrors,transactions,waitstats --collector.logical_disk.volume-exclude=[E]:" ] exited with '0'.
2023-11-14 17:19:58,522 8180 [DEBUG] - Finishing 'Start-ChocolateyProcessAsAdmin'
2023-11-14 17:19:58,532 8180 [INFO ] - prometheus-windows-exporter.install has been installed.
```

